### PR TITLE
Support frozen string literals

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,14 @@ Bundler::GemHelper.install_tasks
 Rake::TestTask.new
 task :default => [:test]
 
+task :test => :set_frozen_string_literal_option
+task :set_frozen_string_literal_option do
+  if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.3"
+    warn "NOTE: Testing support for frozen string literals"
+    ENV['RUBYOPT'] += " --enable-frozen-string-literal --debug=frozen-string-literal"
+  end
+end
+
 task :'pull-css-tests' do
   sh 'git subtree pull -P test/css-parsing-tests https://github.com/SimonSapin/css-parsing-tests.git master --squash'
 end

--- a/lib/crass/parser.rb
+++ b/lib/crass/parser.rb
@@ -73,7 +73,7 @@ module Crass
     #
     def self.stringify(nodes, options = {})
       nodes  = [nodes] unless nodes.is_a?(Array)
-      string = ''
+      string = String.new
 
       nodes.each do |node|
         next if node.nil?
@@ -614,7 +614,7 @@ module Crass
     # Returns the unescaped value of a selector name or property declaration.
     def parse_value(nodes)
       nodes  = [nodes] unless nodes.is_a?(Array)
-      string = ''
+      string = String.new
 
       nodes.each do |node|
         case node[:node]

--- a/lib/crass/tokenizer.rb
+++ b/lib/crass/tokenizer.rb
@@ -273,7 +273,7 @@ module Crass
     #
     # 4.3.15. http://dev.w3.org/csswg/css-syntax/#consume-the-remnants-of-a-bad-url
     def consume_bad_url
-      text = ''
+      text = String.new
 
       until @s.eos?
         if valid_escape?
@@ -373,7 +373,7 @@ module Crass
     #
     # 4.3.12. http://dev.w3.org/csswg/css-syntax/#consume-a-name
     def consume_name
-      result = ''
+      result = String.new
 
       until @s.eos?
         if match = @s.scan(RE_NAME)
@@ -405,7 +405,7 @@ module Crass
     #
     # 4.3.13. http://dev.w3.org/csswg/css-syntax/#consume-a-number
     def consume_number
-      repr = ''
+      repr = String.new
       type = :integer
 
       repr << @s.consume if @s.peek =~ RE_NUMBER_SIGN
@@ -459,7 +459,7 @@ module Crass
     # 4.3.5. http://dev.w3.org/csswg/css-syntax/#consume-a-string-token
     def consume_string(ending = nil)
       ending = @s.current if ending.nil?
-      value  = ''
+      value  = String.new
 
       until @s.eos?
         case char = @s.consume
@@ -499,7 +499,7 @@ module Crass
     #
     # 4.3.7. http://dev.w3.org/csswg/css-syntax/#consume-a-unicode-range-token
     def consume_unicode_range
-      value = @s.scan(RE_HEX) || ''
+      value = @s.scan(RE_HEX) || String.new
 
       while value.length < 6
         break unless @s.peek == '?'
@@ -531,7 +531,7 @@ module Crass
     #
     # 4.3.6. http://dev.w3.org/csswg/css-syntax/#consume-a-url-token
     def consume_url
-      value = ''
+      value = String.new
 
       @s.scan(RE_WHITESPACE)
 


### PR DESCRIPTION
Related to https://github.com/flavorjones/loofah/issues/118, I'd like to ensure that Loofah supports Ruby's "frozen string literals" option.

Essentially this PR turns instances of `''` which are mutated into a call to `String.new`, which returns mutable strings. All changes were driven by failing tests when this option is set.