### PR TITLE
Address `warning: mismatched indentations at 'when' with 'case'`

### DIFF
--- a/lib/crass/parser.rb
+++ b/lib/crass/parser.rb
@@ -402,25 +402,25 @@ module Crass
         case token[:node]
           # Non-standard. Spec says to discard comments and whitespace, but we
           # keep them so we can serialize faithfully.
-          when :comment, :whitespace
-            rules << token
+        when :comment, :whitespace
+          rules << token
 
-          when :cdc, :cdo
-            unless flags[:top_level]
-              @tokens.reconsume
-              rule = consume_qualified_rule
-              rules << rule if rule
-            end
-
-          when :at_keyword
-            @tokens.reconsume
-            rule = consume_at_rule
-            rules << rule if rule
-
-          else
+        when :cdc, :cdo
+          unless flags[:top_level]
             @tokens.reconsume
             rule = consume_qualified_rule
             rules << rule if rule
+          end
+
+        when :at_keyword
+          @tokens.reconsume
+          rule = consume_at_rule
+          rules << rule if rule
+
+        else
+          @tokens.reconsume
+          rule = consume_qualified_rule
+          rules << rule if rule
         end
       end
 

--- a/lib/crass/tokenizer.rb
+++ b/lib/crass/tokenizer.rb
@@ -537,38 +537,38 @@ module Crass
 
       until @s.eos?
         case char = @s.consume
-          when ')'
+        when ')'
+          break
+
+        when RE_WHITESPACE
+          @s.scan(RE_WHITESPACE)
+
+          if @s.eos? || @s.peek == ')'
+            @s.consume
             break
+          else
+            return create_token(:bad_url, :value => value + consume_bad_url)
+          end
 
-          when RE_WHITESPACE
-            @s.scan(RE_WHITESPACE)
+        when '"', "'", '(', RE_NON_PRINTABLE
+          # Parse error.
+          return create_token(:bad_url,
+            :error => true,
+            :value => value + consume_bad_url)
 
-            if @s.eos? || @s.peek == ')'
-              @s.consume
-              break
-            else
-              return create_token(:bad_url, :value => value + consume_bad_url)
-            end
-
-          when '"', "'", '(', RE_NON_PRINTABLE
+        when '\\'
+          if valid_escape?
+            value << consume_escaped
+          else
             # Parse error.
             return create_token(:bad_url,
               :error => true,
-              :value => value + consume_bad_url)
+              :value => value + consume_bad_url
+            )
+          end
 
-          when '\\'
-            if valid_escape?
-              value << consume_escaped
-            else
-              # Parse error.
-              return create_token(:bad_url,
-                :error => true,
-                :value => value + consume_bad_url
-              )
-            end
-
-          else
-            value << char
+        else
+          value << char
         end
       end
 


### PR DESCRIPTION
Address `warning: mismatched indentations at 'when' with 'case'`
and `warning: mismatched indentations at 'else' with 'case'`

Recently Rails railties CI with ruby-head, which is now ruby2.6.0.dev has been failing due to this error.

```
The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).
```

Here are the number of warnings of crass-1.0.3.

```ruby
$ grep warning log.txt  | sort | uniq -c | sort -n |grep crass
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/parser.rb:405: warning: mismatched indentations at 'when' with 'case' at 402
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/parser.rb:408: warning: mismatched indentations at 'when' with 'case' at 402
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/parser.rb:415: warning: mismatched indentations at 'when' with 'case' at 402
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/parser.rb:420: warning: mismatched indentations at 'else' with 'case' at 402
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/tokenizer.rb:540: warning: mismatched indentations at 'when' with 'case' at 539
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/tokenizer.rb:543: warning: mismatched indentations at 'when' with 'case' at 539
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/tokenizer.rb:553: warning: mismatched indentations at 'when' with 'case' at 539
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/tokenizer.rb:559: warning: mismatched indentations at 'when' with 'case' at 539
  68 /home/travis/.rvm/gems/ruby-head/gems/crass-1.0.3/lib/crass/tokenizer.rb:570: warning: mismatched indentations at 'else' with 'case' at 539
$
```

These warnings can be reproduced by running rake command.

```ruby
$ rake
NOTE: Testing support for frozen string literals
/home/yahonda/git/crass/lib/crass/parser.rb:405: warning: mismatched indentations at 'when' with 'case' at 402
/home/yahonda/git/crass/lib/crass/parser.rb:408: warning: mismatched indentations at 'when' with 'case' at 402
/home/yahonda/git/crass/lib/crass/parser.rb:415: warning: mismatched indentations at 'when' with 'case' at 402
/home/yahonda/git/crass/lib/crass/parser.rb:420: warning: mismatched indentations at 'else' with 'case' at 402
/home/yahonda/git/crass/lib/crass/tokenizer.rb:540: warning: mismatched indentations at 'when' with 'case' at 539
/home/yahonda/git/crass/lib/crass/tokenizer.rb:543: warning: mismatched indentations at 'when' with 'case' at 539
/home/yahonda/git/crass/lib/crass/tokenizer.rb:553: warning: mismatched indentations at 'when' with 'case' at 539
/home/yahonda/git/crass/lib/crass/tokenizer.rb:559: warning: mismatched indentations at 'when' with 'case' at 539
/home/yahonda/git/crass/lib/crass/tokenizer.rb:570: warning: mismatched indentations at 'else' with 'case' at 539
Run options: --seed 1077

... snip ...
$
```

#### How to address these warnings

These warnings can be addressed by using RuboCop. I do not request to install RuboCop permanently in this repository then just created it temporary and remove them.

- Create .rubocop_todo.yml file 
```
$ rubocop --auto-gen-config
```

- Edit `.rubocop_todo.yml` generated and modify as follows.
```
 41 Layout/CaseIndentation:
 42   Exclude:
 43     - 'lib/crass/parser.rb'
 44     - 'lib/crass/tokenizer.rb'
 45     - 'test/support/common.rb'
```

- Replace `Exclude` with `Include` under `Layout/CaseIndentication:`
and remove test/support/common.rb' since only lib/crass/parser.rb and lib/crass/tokenizer.rb files are reported by rake.

```
 41 Layout/CaseIndentation:
 42   Include:
 43     - 'lib/crass/parser.rb'
 44     - 'lib/crass/tokenizer.rb'
 45
```
- Execute rubocop -a (--auto-correct) option
```
$ rubocop -a
```

- Remove .rubocop.yml and .rubocop_todo.yml
```
$ rm .rubocop.yml .rubocop_todo.yml
```