### PR TITLE
Remove test files from bundled gem

### DIFF
--- a/crass.gemspec
+++ b/crass.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
 
-  s.files      = `git ls-files`.split($/)
-  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+  s.files = `git ls-files -z`.split("\x0").grep_v(%r{^test/})
 
   # Development dependencies.
   s.add_development_dependency 'minitest', '~> 5.0.8'


### PR DESCRIPTION
## Summary

This PR slims down the bundled gem by 80%.

|                       | Gem Size (bytes) |
|-----------------------|-----------------:|
| Before                |           92,160 |
| After                 |           18,432 |
| Difference (absolute) |           73,728 |
| Difference (relative) |          -80.00% |

I believe these savings are worth having because this gem is downloaded millions of times.

## Changes

- Removed the `test_files` declaration from the gemspec (because it is ["no longer useful or recommended to set"](https://github.com/rubygems/guides/issues/90))
- Omitted all test files from the gem.

<details>
<summary>Before (details)</summary>

```
## Gem size
-rw-r--r-- 1 tom users 92160 Oct 15 22:57 pkg/crass-1.0.4.gem

## Gem contents
.gitignore
.travis.yml
.yardopts
Gemfile
HISTORY.md
LICENSE
README.md
Rakefile
crass.gemspec
lib/crass.rb
lib/crass/parser.rb
lib/crass/scanner.rb
lib/crass/token-scanner.rb
lib/crass/tokenizer.rb
lib/crass/version.rb
test/css-parsing-tests/An+B.json
test/css-parsing-tests/LICENSE
test/css-parsing-tests/README.rst
test/css-parsing-tests/color3.json
test/css-parsing-tests/color3_hsl.json
test/css-parsing-tests/color3_keywords.json
test/css-parsing-tests/component_value_list.json
test/css-parsing-tests/declaration_list.json
test/css-parsing-tests/make_color3_hsl.py
test/css-parsing-tests/make_color3_keywords.py
test/css-parsing-tests/one_component_value.json
test/css-parsing-tests/one_declaration.json
test/css-parsing-tests/one_rule.json
test/css-parsing-tests/rule_list.json
test/css-parsing-tests/stylesheet.json
test/css-parsing-tests/stylesheet_bytes.json
test/shared/parse_rules.rb
test/support/common.rb
test/support/serialization/animate.css
test/support/serialization/bootstrap-theme.css
test/support/serialization/bootstrap.css
test/support/serialization/html5-boilerplate.css
test/support/serialization/misc.css
test/support/serialization/pure.css
test/test_crass.rb
test/test_css_parsing_tests.rb
test/test_parse_properties.rb
test/test_parse_rules.rb
test/test_parse_stylesheet.rb
test/test_serialization.rb
```
</details>

<details>
<summary>After (details)</summary>

```
## Gem size
-rw-r--r-- 1 tom users 18432 Oct 15 22:57 pkg/crass-1.0.4.gem

## Gem contents
.gitignore
.travis.yml
.yardopts
Gemfile
HISTORY.md
LICENSE
README.md
Rakefile
crass.gemspec
lib/crass.rb
lib/crass/parser.rb
lib/crass/scanner.rb
lib/crass/token-scanner.rb
lib/crass/tokenizer.rb
lib/crass/version.rb
```
</details>
