### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/crass.gemspec
+++ b/crass.gemspec
@@ -11,6 +11,13 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/rgrove/crass/'
   s.license     = 'MIT'
 
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rgrove/crass/issues',
+    'changelog_uri'     => "https://github.com/rgrove/crass/blob/v#{s.version}/HISTORY.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/crass/#{s.version}",
+    'source_code_uri'   => "https://github.com/rgrove/crass/tree/v#{s.version}",
+  }
+
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = Gem::Requirement.new('>= 1.9.2')
 


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/crass), via the Rubygems API, and the `gem` and `bundle` command-line tools with the next release.